### PR TITLE
Follow symlink

### DIFF
--- a/username-anarchy
+++ b/username-anarchy
@@ -7,8 +7,9 @@
 
 
 ## set up load paths. add the directory of the file currently being executed to the load path
-$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless
-    $:.include?(File.dirname(__FILE__)) || $LOAD_PATH.include?(File.expand_path(File.dirname(__FILE__)))
+real_file_path = File.dirname(File.realpath(__FILE__))
+$LOAD_PATH.unshift(File.realpath(real_file_path)) unless
+    $:.include?(real_file_path) || $LOAD_PATH.include?(File.expand_path(real_file_path))
 
 $ROOT_DIR = File.expand_path(File.dirname(__FILE__)) + "/"
 $VERSION = "0.5"

--- a/username-anarchy
+++ b/username-anarchy
@@ -8,7 +8,7 @@
 
 ## set up load paths. add the directory of the file currently being executed to the load path
 real_file_path = File.dirname(File.realpath(__FILE__))
-$LOAD_PATH.unshift(File.realpath(real_file_path)) unless
+$LOAD_PATH.unshift(File.expand_path(real_file_path)) unless
     $:.include?(real_file_path) || $LOAD_PATH.include?(File.expand_path(real_file_path))
 
 $ROOT_DIR = File.expand_path(File.dirname(__FILE__)) + "/"


### PR DESCRIPTION
Added functionality to the script to enable its usage via bash from any part of the filesystem by creating a symlink of the main script. 
Implemented **File.realpath** to properly follow the **__FILE__** in case it is a symlink.
This addition does not interfere with the correct behavior of the script.