### PR TITLE
Fix for Ruby 3.2.0

### DIFF
--- a/username-anarchy
+++ b/username-anarchy
@@ -235,7 +235,7 @@ end
 
 def load_names_list(filename)
 	# check f is a file and readable
-	raise "#{filename}: No such file" unless File.exists?(filename)
+	raise "#{filename}: No such file" unless File.exist?(filename)
 	raise "#{filename}: Cannot read file" unless File.readable?(filename)
 
 	lines = File.readlines(filename)
@@ -674,4 +674,3 @@ people.each do |person|
 	end
 #	pp generated_names
 end
-


### PR DESCRIPTION
```
➜ ./username-anarchy -i test-names.txt
./username-anarchy:238:in `load_names_list': undefined method `exists?' for File:Class (NoMethodError)

        raise "#{filename}: No such file" unless File.exists?(filename)
                                                     ^^^^^^^^
Did you mean?  exist?
        from ./username-anarchy:606:in `<main>'
```

Starting in `Ruby 3.2.0` the `exists?` (pluralized) alias for `exist?` seems to has been removed.

Fixed it by renaming `File.exists` to `File.exist` on line 238.