### PR TITLE
Add new username format plugins and hyphen separator formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://raw.githubusercontent.com/urbanadventurer/username-anarchy/master/LICENSE) ![Stable Release](https://img.shields.io/badge/stable_release-0.6-blue.svg) [![Repositories](https://repology.org/badge/tiny-repos/username-anarchy.svg)](https://repology.org/project/username-anarchy/versions)
+[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://raw.githubusercontent.com/urbanadventurer/username-anarchy/master/LICENSE) ![Stable Release](https://img.shields.io/badge/stable_release-0.7-blue.svg) [![Repositories](https://repology.org/badge/tiny-repos/username-anarchy.svg)](https://repology.org/project/username-anarchy/versions)
 
 Username Anarchy
 ======================================
 
-* Version: 0.6 (20 September 2024)
+* Version: 0.7 (01 March 2026)
 * Author: urbanadventurer (Andrew Horton)
 * Homepage: https://www.morningstarsecurity.com/research/username-anarchy
 * Source: https://github.com/urbanadventurer/username-anarchy/
@@ -53,7 +53,7 @@ Username Anarchy is a command line tool.
 	    \____:__  /|___:__/(______)|__|    \_____)|___:__//_____|   
 	            \/                                                  
 	Usage: ./username-anarchy [OPTIONS]... [firstname|first last|first middle last]
-	Author: Andrew Horton (urbanadventurer). Version: 0.5
+	Author: Andrew Horton (urbanadventurer). Version: 0.7
 
 	Names:
 	 -i, --input-file FILE     Input list of names. Can be SPACE, CSV or TAB delimited.
@@ -172,6 +172,18 @@ Note that -a or --auto is required when you do not specify any input names.
 	First.Last          	Anna.Key
 	Last                	Key
 	FML                 	ABK
+	first.l             	anna.k
+	LastFirst           	Keyanna
+	Last.First          	Key.Anna
+	LastF               	KeyA
+	first-last          	anna-key
+	last-first          	key-anna
+	f-last              	a-key
+	first-l             	anna-k
+	last-f              	key-a
+	l-first             	k-anna
+	Last-First          	Key-Anna
+	First-Last          	Anna-Key
 
 
 ### Automatically recognise the username format in use
@@ -274,7 +286,7 @@ Username Anarchy provides a method of defining a username format with format str
 
 ### ABK Format
 Username Anarchy provides a method of defining a username format with ABK format which translates
-to format strings.
+to format strings. Separators such as `.` and `-` pass through as literals.
 
 * Anna - %F
 * Boom - %M 
@@ -313,6 +325,3 @@ Name Resources
 * https://secure.wikimedia.org/wikipedia/en/wiki/Capitalization
 * http://cpansearch.perl.org/src/KIMRYAN/Lingua-EN-NameParse-1.28/lib/Lingua/EN/NameParse.pm
 * http://search.cpan.org/~summer/Lingua-EN-NameCase/NameCase.pm
-
-
-

--- a/format-plugins.rb
+++ b/format-plugins.rb
@@ -1,205 +1,240 @@
 # Copyright
 # Part of Username Anarchy
-
 class Plugin
 	attr_accessor :plugin_name
 	@registered_plugins = []
-
 	class << self
 		attr_reader :registered_plugins
 		private :new
 	end
-
 	def self.define(name, &block)
 		p = new
 		p.instance_eval(&block)
 		p.plugin_name = name
 		Plugin.registered_plugins << p
 	end
-
 end
-
-
 Plugin.define "first" do
 	def generate(n)
 		n.format("%f")
 	end
 end
-
 Plugin.define "firstlast" do
 	def generate(n)
 		n.format_anna("annakey")
 	end
 end
-
-
 Plugin.define "first.last" do
 	def generate(n)
 		#n.format("%f.%l")
 		n.format_anna("anna.key")
 	end
 end
-
 Plugin.define "firstlast[8]" do
 	def generate(n)
 		# fix this. truncated to 8
 		(n.firstname + n.lastname).to_s[0..7] unless n.firstname.nil? or n.lastname.nil?		
 	end
 end
-
 Plugin.define "first[4]last[4]" do
 	def generate(n)		
 		(n.firstname.to_s[0..3]) + (n.lastname.to_s[0..3]) unless n.firstname.nil? or n.lastname.nil?
 	end
 end
-
 Plugin.define "firstl" do
 	def generate(n)
 		#n.format("%f.%l")
 		n.format_anna("annak")
 	end
 end
-
 Plugin.define "f.last" do
 	def generate(n)
 		#n.format("%i.F.%L")
 		n.format_anna("a.key")
 	end
 end
-
 Plugin.define "flast" do
 	def generate(n)
 		#n.format("%i.F.%L")
 		n.format_anna("akey")
 	end
 end
-
 Plugin.define "lfirst" do
 	def generate(n)
 		n.format_anna("kanna")
 	end
 end
-
 Plugin.define "l.first" do
 	def generate(n)
 		n.format_anna("k.anna")
 	end
 end
-
 Plugin.define "lastf" do
 	def generate(n)
 		n.format_anna("keya")
 	end
 end
-
-
 Plugin.define "last" do
 	def generate(n)
 		n.format_anna("key")
 	end
 end
-
 Plugin.define "last.f" do
 	def generate(n)
 		n.format_anna("key.a")
 	end
 end
-
 Plugin.define "last.first" do
 	def generate(n)
 		n.format_anna("key.anna")
 	end
 end
-
 Plugin.define "FLast" do
 	def generate(n)
 		#n.firstinitial + n.lastname
 		n.format_anna("AKey")
 	end
 end
-
 Plugin.define "first1" do
 	def generate(n)
 		n.format_anna("anna%D")
 	end
 end
-
 Plugin.define "fl" do
 	def generate(n)
 		#n.firstinitial + n.lastname
 		n.format_anna("ak")
 	end
 end
-
 Plugin.define "fmlast" do
 	def generate(n)
 		#n.firstinitial + n.lastname
 		n.format_anna("abkey")
 	end
 end
-
-
 Plugin.define "firstmiddlelast" do
 	def generate(n)
 		#n.firstinitial + n.lastname
 		n.format_anna("annaboomkey")
 	end
 end
-
 Plugin.define "fml" do
 	def generate(n)
 		#n.firstinitial + n.lastname
 		n.format_anna("abk")
 	end
 end
-
 #Plugin.define "canterbury-uni" do
 #	def generate(n)
 #		#n.firstinitial + n.lastname
 #		n.format_anna("abk%DD")
 #	end
 #end
-
 Plugin.define "FL" do
 	def generate(n)
 		#n.firstinitial + n.lastname
 		n.format_anna("AK")
 	end
 end
-
-
 Plugin.define "FirstLast" do
 	def generate(n)
 		n.format_anna("%F%L")
 	end
 end
-
 Plugin.define "First.Last" do
 	def generate(n)
 		n.format_anna("%F.%L")
 	end
 end
-
 Plugin.define "Last" do
 	def generate(n)
 		n.format_anna("Key")
 	end
 end
+Plugin.define "first.l" do
+	def generate(n)
+		# john.d
+		n.format_anna("anna.k")
+	end
+end
+Plugin.define "LastFirst" do
+	def generate(n)
+		# DoeJohn
+		n.format_anna("Keyanna")
+	end
+end
+Plugin.define "Last.First" do
+	def generate(n)
+		# Doe.John
+		n.format_anna("Key.Anna")
+	end
+end
+Plugin.define "LastF" do
+	def generate(n)
+		# DoeJ
+		n.format_anna("KeyA")
+	end
+end
+Plugin.define "first-last" do
+	def generate(n)
+		# john-doe
+		n.format_anna("anna-key")
+	end
+end
+Plugin.define "last-first" do
+	def generate(n)
+		# doe-john
+		n.format_anna("key-anna")
+	end
+end
+Plugin.define "f-last" do
+	def generate(n)
+		# j-doe
+		n.format_anna("a-key")
+	end
+end
+Plugin.define "first-l" do
+	def generate(n)
+		# john-d
+		n.format_anna("anna-k")
+	end
+end
+Plugin.define "last-f" do
+	def generate(n)
+		# doe-j
+		n.format_anna("key-a")
+	end
+end
+Plugin.define "l-first" do
+	def generate(n)
+		# d-john
+		n.format_anna("k-anna")
+	end
+end
+Plugin.define "Last-First" do
+	def generate(n)
+		# Doe-John
+		n.format_anna("Key-Anna")
+	end
+end
+Plugin.define "First-Last" do
+	def generate(n)
+		# John-Doe
+		n.format_anna("Anna-Key")
+	end
+end
 =begin
-
 Plugin.define "FML" do
 	def generate(n)
 		# this is the sort of code I want to avoid
 		s=""
 		s+=n.firstinitial.downcase
-
 		if n.middleinitial
 			s+=n.middleinitial
 		else
 			s+="~"
 		end
 		s+=n.lastinitial.downcase
-
 		if s=~/~/
 			names=('a'..'z').map {|letter| s.sub('~',letter) }
 			s=names
@@ -209,4 +244,3 @@ Plugin.define "FML" do
 	end
 end
 =end
-


### PR DESCRIPTION
## Summary
Adds 13 new format plugins to `format-plugins.rb`, covering two areas:

**New dot and initial formats:**
- `first.l` — firstname, dot, last initial (e.g. `john.d`)
- `LastFirst` — lastname concatenated with firstname (e.g. `DoeJohn`)
- `Last.First` — lastname, dot, firstname (e.g. `Doe.John`)
- `LastF` — lastname, first initial (e.g. `DoeJ`)

**Hyphen equivalents for all existing dot-separated formats:**
- `first-last` (e.g. `john-doe`)
- `last-first` (e.g. `doe-john`)
- `f-last` (e.g. `j-doe`)
- `first-l` (e.g. `john-d`)
- `last-f` (e.g. `doe-j`)
- `l-first` (e.g. `d-john`)
- `Last-First` (e.g. `Doe-John`)
- `First-Last` (e.g. `John-Doe`)

## Changes
- `format-plugins.rb` — new plugins added before the `=begin` block
- `README.md` — updated `--list-formats` example output to reflect new plugins